### PR TITLE
Authentication method tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ before_script:
 - npm install -g grunt-cli
 script: npm run full-test
 after_success:
-- if [ "master" -ne "$TRAVIS_BRANCH" ]; then exit 0; fi;
+- if [ "master" != "$TRAVIS_BRANCH" ]; then exit 0; fi;
 - git config --global user.email "deploy@travis-ci.org"
 - git config --global user.name "Travis deploy"
 - git remote add github "https://${GH_TOKEN}@github.com/node-xmpp/node-xmpp-client.git"

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ before_script:
 - npm install -g grunt-cli
 script: npm run full-test
 after_success:
-- if [ "master" -ne $TRAVIS_BRANCH ]; then exit 0; fi;
+- if [ "master" -ne "$TRAVIS_BRANCH" ]; then exit 0; fi;
 - git config --global user.email "deploy@travis-ci.org"
 - git config --global user.name "Travis deploy"
 - git remote add github "https://${GH_TOKEN}@github.com/node-xmpp/node-xmpp-client.git"

--- a/test/browser/bosh/bosh.js
+++ b/test/browser/bosh/bosh.js
@@ -215,4 +215,81 @@ describe('BOSH Browser tests', function(){
         })
     })
     
+    describe('Authentication', function() {
+    
+        it('Can connect using PLAIN authentication', function(done) {
+            client = new window.XMPP.Client({
+                jid: jid,
+                password: password,
+                bosh: {
+                    url: 'http://localhost:5280/http-bind/'
+                },
+                preferred: 'PLAIN'
+            })
+
+            var ping = new window.XMPP.ltx.Element(
+                'iq', { id: '123', type: 'get' }
+            ).c('ping', { xmlns: 'urn:xmpp:ping' })
+
+            client.on('online', function() {
+                client.send(ping)
+                client.on('stanza', function(pong) {
+                    pong.attrs.id.should.equal('123')
+                    done()
+                })
+            })
+        })
+    
+        it.skip('Can connect using DIGEST-MD5 authentication', function(done) {
+            client = new window.XMPP.Client({
+                jid: jid,
+                password: password,
+                bosh: {
+                    url: 'http://localhost:5280/http-bind/'
+                },
+                preferred: 'DIGEST-MD5'
+            })
+
+            var ping = new window.XMPP.ltx.Element(
+                'iq', { id: '123', type: 'get' }
+            ).c('ping', { xmlns: 'urn:xmpp:ping' })
+
+            client.on('error', function(error) {
+                done(error)
+            })
+            client.on('online', function() {
+                client.send(ping)
+                client.on('stanza', function(pong) {
+                    pong.attrs.id.should.equal('123')
+                    done()
+                })
+            })
+        })
+        
+        it('Can connect using ANONYMOUS authentication', function(done) {
+            client = new window.XMPP.Client({
+                jid: '@anon.localhost',
+                password: password,
+                host: 'localhost',
+                bosh: {
+                    url: 'http://localhost:5280/http-bind/'
+                },
+                preferred: 'ANONYMOUS'
+            })
+
+            var ping = new window.XMPP.ltx.Element(
+                'iq', { id: '123', type: 'get' }
+            ).c('ping', { xmlns: 'urn:xmpp:ping' })
+
+            client.on('online', function() {
+                client.send(ping)
+                client.on('stanza', function(pong) {
+                    pong.attrs.id.should.equal('123')
+                    done()
+                })
+            })
+        })
+    
+    })
+    
 })

--- a/test/integration/bosh.js
+++ b/test/integration/bosh.js
@@ -272,5 +272,79 @@ describe('BOSH connections', function() {
         })
         
     })
+    
+    describe('Authentication', function() {
+    
+        it('Can connect using PLAIN authentication', function(done) {
+            client = new Client({
+                jid: jid,
+                password: password,
+                bosh: {
+                    url: 'http://localhost:5280/http-bind/'
+                },
+                preferred: 'PLAIN'
+            })
+
+            var ping = new Element(
+                'iq', { id: '123', type: 'get' }
+            ).c('ping', { xmlns: 'urn:xmpp:ping' })
+
+            client.on('online', function() {
+                client.send(ping)
+                client.on('stanza', function(pong) {
+                    pong.attrs.id.should.equal('123')
+                    done()
+                })
+            })
+        })
+    
+        it('Can connect using DIGEST-MD5 authentication', function(done) {
+            client = new Client({
+                jid: jid,
+                password: password,
+                bosh: {
+                    url: 'http://localhost:5280/http-bind/'
+                },
+                preferred: 'DIGEST-MD5'
+            })
+
+            var ping = new Element(
+                'iq', { id: '123', type: 'get' }
+            ).c('ping', { xmlns: 'urn:xmpp:ping' })
+
+            client.on('online', function() {
+                client.send(ping)
+                client.on('stanza', function(pong) {
+                    pong.attrs.id.should.equal('123')
+                    done()
+                })
+            })
+        })
+        
+        it('Can connect using ANONYMOUS authentication', function(done) {
+            client = new Client({
+                jid: '@anon.localhost',
+                password: password,
+                host: 'localhost',
+                bosh: {
+                    url: 'http://localhost:5280/http-bind/'
+                },
+                preferred: 'ANONYMOUS'
+            })
+
+            var ping = new Element(
+                'iq', { id: '123', type: 'get' }
+            ).c('ping', { xmlns: 'urn:xmpp:ping' })
+
+            client.on('online', function() {
+                client.send(ping)
+                client.on('stanza', function(pong) {
+                    pong.attrs.id.should.equal('123')
+                    done()
+                })
+            })
+        })
+        
+    })
 
 })

--- a/test/integration/socket.js
+++ b/test/integration/socket.js
@@ -188,4 +188,71 @@ describe('Socket connections', function() {
         })
     })
     
+    
+    describe('Authentication', function() {
+    
+        it('Can connect using PLAIN authentication', function(done) {
+            client = new Client({
+                jid: jid,
+                password: password,
+                host: 'localhost',
+                preferred: 'PLAIN'
+            })
+
+            var ping = new Element(
+                'iq', { id: '123', type: 'get' }
+            ).c('ping', { xmlns: 'urn:xmpp:ping' })
+
+            client.on('online', function() {
+                client.send(ping)
+                client.on('stanza', function(pong) {
+                    pong.attrs.id.should.equal('123')
+                    done()
+                })
+            })
+        })
+    
+        it('Can connect using DIGEST-MD5 authentication', function(done) {
+            client = new Client({
+                jid: jid,
+                password: password,
+                host: 'localhost',
+                preferred: 'DIGEST-MD5'
+            })
+
+            var ping = new Element(
+                'iq', { id: '123', type: 'get' }
+            ).c('ping', { xmlns: 'urn:xmpp:ping' })
+
+            client.on('online', function() {
+                client.send(ping)
+                client.on('stanza', function(pong) {
+                    pong.attrs.id.should.equal('123')
+                    done()
+                })
+            })
+        })
+    
+        it('Can connect using ANONYMOUS authentication', function(done) {
+            client = new Client({
+                jid: '@anon.localhost',
+                password: password,
+                host: 'localhost',
+                preferred: 'ANONYMOUS'
+            })
+
+            var ping = new Element(
+                'iq', { id: '123', type: 'get' }
+            ).c('ping', { xmlns: 'urn:xmpp:ping' })
+
+            client.on('online', function() {
+                client.send(ping)
+                client.on('stanza', function(pong) {
+                    pong.attrs.id.should.equal('123')
+                    done()
+                })
+            })
+        })
+    })
+    
 })

--- a/test/resources/prosody.cfg.lua
+++ b/test/resources/prosody.cfg.lua
@@ -49,8 +49,8 @@ Component "component.localhost"
 
 VirtualHost "anon.localhost"
    authentication = "anonymous"
-	enabled = true
-    ssl = {
-		key = "/etc/prosody/certs/example.com.key";
-		certificate = "/etc/prosody/certs/example.com.crt";
-	}
+   enabled = true
+   ssl = {
+	key = "/etc/prosody/certs/example.com.key";
+	certificate = "/etc/prosody/certs/example.com.crt";
+   }

--- a/test/resources/prosody.cfg.lua
+++ b/test/resources/prosody.cfg.lua
@@ -46,3 +46,11 @@ VirtualHost "localhost"
 
 Component "component.localhost"
 	component_secret = "mysecretcomponentpassword"
+
+VirtualHost "anon.localhost"
+   authentication = "anonymous"
+	enabled = true
+    ssl = {
+		key = "/etc/prosody/certs/example.com.key";
+		certificate = "/etc/prosody/certs/example.com.crt";
+	}


### PR DESCRIPTION
Tests for __PLAIN__, __DIGEST-MD5__, and __ANONYMOUS__ authentication methods in integration and browser based tests.

Note: Skipped __DISGEST-MD5__ test in the browser based BOSH test. This issue is documented in #15.