### PR TITLE
Default BOSH wait to 60s

### DIFF
--- a/lib/bosh.js
+++ b/lib/bosh.js
@@ -12,7 +12,7 @@ function BOSHConnection(opts) {
 
     this.boshURL = opts.bosh.url
     this.jid = opts.jid
-    this.wait = opts.bosh.wait || 60;
+    this.wait = opts.bosh.wait || 60
     this.xmlnsAttrs = {
         xmlns: 'http://jabber.org/protocol/httpbind',
         'xmlns:xmpp': 'urn:xmpp:xbosh',
@@ -176,7 +176,7 @@ BOSHConnection.prototype.request = function(attrs, children, cb, retry) {
         boshEl.cnode(children[i])
     }
 
-    debug('send bosh request:' + boshEl.toString());
+    debug('send bosh request:' + boshEl.toString())
 
     request({
             uri: this.boshURL,

--- a/lib/bosh.js
+++ b/lib/bosh.js
@@ -12,7 +12,7 @@ function BOSHConnection(opts) {
 
     this.boshURL = opts.bosh.url
     this.jid = opts.jid
-    this.wait = opts.bosh.wait || 10;
+    this.wait = opts.bosh.wait || 60;
     this.xmlnsAttrs = {
         xmlns: 'http://jabber.org/protocol/httpbind',
         'xmlns:xmpp': 'urn:xmpp:xbosh',


### PR DESCRIPTION
```10``` is way too small for 'standard' configurationm ```60``` is pretty much de facto standard.