### PR TITLE
Update deprecated crypto call

### DIFF
--- a/lib/session.js
+++ b/lib/session.js
@@ -2,7 +2,6 @@
 
 var util = require('util')
   , tls = require('tls')
-  , crypto = require('crypto')
   , EventEmitter = require('events').EventEmitter
   , Connection = require('node-xmpp-core').Connection
   , JID = require('node-xmpp-core').JID
@@ -75,8 +74,8 @@ Session.prototype._socketConnectionToHost = function(opts) {
         })
     } else {
         if (opts.credentials) {
-            this.connection.credentials = crypto
-                .createCredentials(opts.credentials)
+            this.connection.credentials = tls
+                .createSecureContext(opts.credentials)
         }
         if (opts.disallowTLS) this.connection.allowTLS = false
         this.connection.listen({
@@ -98,7 +97,7 @@ Session.prototype._performSrvLookup = function(opts) {
         throw 'LegacySSL mode does not support DNS lookups'
     }
     if (opts.credentials)
-        this.connection.credentials = crypto.createCredentials(opts.credentials)
+        this.connection.credentials = tls.createSecureContext(opts.credentials)
     if (opts.disallowTLS)
         this.connection.allowTLS = false
     this.connection.listen({socket:SRV.connect({


### PR DESCRIPTION
According to the [docs](http://nodejs.org/api/crypto.html#crypto_crypto_createcredentials_details), `crypto.createCredentials` is deprecated in favour of `tls.createSecureContext`