### PR TITLE
[Security] Upgrade request to 2.55

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "url": "https://github.com/node-xmpp/node-xmpp-client/issues"
   },
   "dependencies": {
-    "request": "~2.48.0",
+    "request": "~2.55.0",
     "faye-websocket": "~0.7.0",
     "node-xmpp-core": "~1.0.0-alpha10",
     "browser-request": "~0.3.1",


### PR DESCRIPTION
```
Name  Installed  Patched  Vulnerable Dependency
qs      0.6.6     >= 1.x  node-xmpp-client@1.0.0-alpha9 > request@2.27.0 > qs@0.6.6
```

See:

- https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2014-7191
- https://nodesecurity.io/advisories/qs_dos_memory_exhaustion