### PR TITLE
Update dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,29 +26,31 @@
     "url": "https://github.com/node-xmpp/node-xmpp-client/issues"
   },
   "dependencies": {
-    "request": "~2.55.0",
-    "faye-websocket": "~0.7.0",
+    "request": "^2.61.0",
+    "faye-websocket": "^0.10.0",
     "node-xmpp-core": "^2.0.0",
-    "browser-request": "~0.3.1",
-    "minimist": "0.0.8",
-    "debug": "~1.0.0"
+    "browser-request": "^0.3.3",
+    "minimist": "^1.2.0",
+    "debug": "^2.2.0"
   },
   "devDependencies": {
-    "brfs": "0.0.8",
-    "browserify": "~3.19.1",
-    "coveralls": "^2.11.2",
-    "grunt": "~0.4.2",
-    "grunt-browserify": "~1.3.0",
+    "brfs": "^1.4.1",
+    "browserify": "^3.19.1",
+    "coveralls": "^2.11.4",
+    "grunt": "^0.4.5",
+    "grunt-browserify": "^1.3.0",
     "grunt-cli": "^0.1.13",
-    "grunt-contrib-clean": "~0.5.0",
-    "grunt-contrib-connect": "^0.9.0",
-    "grunt-contrib-jshint": "~0.7.2",
-    "grunt-contrib-watch": "~0.5.3",
-    "grunt-mocha-cli": "~1.3.0",
-    "grunt-mocha-istanbul": "^2.1.0",
+    "grunt-contrib-clean": "^0.6.0",
+    "grunt-contrib-connect": "^0.11.2",
+    "grunt-contrib-jshint": "^0.11.3",
+    "grunt-contrib-watch": "^0.6.1",
+    "grunt-mocha-cli": "^1.14.0",
+    "grunt-mocha-istanbul": "^3.0.1",
     "grunt-mocha-phantomjs": "^2.0.0",
+    "istanbul": "^0.3.19",
+    "mocha": "^2.3.2",
     "node-xmpp-server": "^1.0.2",
-    "should": "~2.1.1"
+    "should": "^7.1.0"
   },
   "browser": {
     "request": "browser-request",


### PR DESCRIPTION
browserify and grunt-browserify were not updated because I'd get the following error:
```
Running "browserify:dist" (browserify) task
>> Error: Cannot find module '' from '/Users/sonny/Projects/node-xmpp/client'
Warning: Error running grunt-browserify. Use --force to continue.
```