### PR TITLE
Bug fixed when using the option legacySSL:true.

### DIFF
--- a/lib/session.js
+++ b/lib/session.js
@@ -55,6 +55,8 @@ Session.prototype._setupSocketConnection = function(opts) {
 }
 
 Session.prototype._socketConnectionToHost = function(opts) {
+    var _this = this;
+
     if (opts.legacySSL) {
         this.connection.allowTLS = false
         this.connection.connect({
@@ -65,9 +67,9 @@ Session.prototype._socketConnectionToHost = function(opts) {
                     opts.credentials || {},
                     function() {
                         if (this.socket.authorized)
-                            this.emit('connect', this.socket)
+                            _this.emit('connect', this.socket)
                         else
-                            this.emit('error', 'unauthorized')
+                            _this.emit('error', 'unauthorized')
                     }.bind(this)
                 )
             }


### PR DESCRIPTION
There was a logic error when using 'this' reference in a callback in the file session.js, in the code, 'this' was pointing to a tls socket instance instead of pointing to our session object. It was solved keeping a session reference in a local variable called _this so, even in nested callbacks the session reference can be accessed.